### PR TITLE
Implement #3: Simplify sql grammar.

### DIFF
--- a/src/main/antlr/net/ninjacat/rowcp/Rsql.g4
+++ b/src/main/antlr/net/ninjacat/rowcp/Rsql.g4
@@ -6,25 +6,9 @@ package net.ninjacat.rowcp;
 
 query: selectStatement ';'? EOF;
 
-operator: '<' | '<=' | '>' | '>=' | '=' | '!=' | '<>';
+where: K_WHERE anything;
 
-list: '(' literalValue (',' literalValue)* ')';
-
-term: compoundName | literalValue;
-
-expr:
-	term operator term							# condition
-	| expr K_AND expr							# andExpr
-	| expr K_OR expr							# orExpr
-	| expr K_IS K_NOT? K_NULL                                               # isNullExpr
-	| K_NOT expr								# notExpr
-	| '(' expr ')'								# parensExpr
-	| term K_BETWEEN expr K_AND expr			# betweenExpr
-	| term K_NOT? K_LIKE stringValue			# likeExpr
-	| term K_NOT? K_IN list						# inExpr
-	| term K_NOT? K_IN '(' selectStatement ')'	# subSelectExpr;
-
-where: K_WHERE expr;
+anything: .*?;
 
 distinct: K_DISTINCT;
 
@@ -32,49 +16,18 @@ projection: distinct? K_ALL;
 
 selectStatement: K_SELECT projection K_FROM sourceName where?;
 
-signedNumber: ( '+' | '-')? NUMERIC_LITERAL;
-
-stringValue: STRING_LITERAL;
-
-nullValue: K_NULL;
-
-literalValue: signedNumber | stringValue | nullValue;
-
 alias: IDENTIFIER;
 
 sourceName: name alias?;
 
-compoundName: (qualifier '.')? name;
-
 name: IDENTIFIER;
 
-qualifier: IDENTIFIER;
-
 K_ALL: '*';
-K_AND: A N D;
 K_AS: A S;
-K_BETWEEN: B E T W E E N;
 K_FROM: F R O M;
-K_IN: I N;
-K_NOT: N O T;
-K_NULL: N U L L;
-K_OR: O R;
-K_REGEX: R E G E X;
 K_SELECT: S E L E C T;
-K_MATCH: M A T C H;
-K_WHERE: W H E R E;
-K_TRUE: T R U E;
-K_FALSE: F A L S E;
-K_JOIN: J O I N;
-K_LEFT: L E F T;
-K_RIGHT: R I G H T;
-K_OUTER: O U T E R;
-K_INNER: I N N E R;
-K_CROSS: C R O S S;
-K_ON: O N;
 K_DISTINCT: D I S T I N C T;
-K_LIKE: L I K E;
-K_IS: I S;
+K_WHERE: W H E R E;
 
 IDENTIFIER: SIMPLE_IDENTIFIER | QUOTED_IDENTIFIER;
 

--- a/src/main/kotlin/net/ninjacat/rowcp/query/QueryListener.kt
+++ b/src/main/kotlin/net/ninjacat/rowcp/query/QueryListener.kt
@@ -17,8 +17,8 @@ class QueryListener(private val src: String) : RsqlBaseListener() {
 
     override fun exitWhere(ctx: RsqlParser.WhereContext?) {
         super.exitWhere(ctx)
-        val start = ctx!!.expr().getStart().startIndex
-        val end = ctx.expr().stop.stopIndex
+        val start = ctx!!.anything().getStart().startIndex
+        val end = ctx.anything().stop.stopIndex
         filter = src.substring(start, end + 1)
     }
 

--- a/src/test/kotlin/net/ninjacat/rowcp/query/QueryParserTest.kt
+++ b/src/test/kotlin/net/ninjacat/rowcp/query/QueryParserTest.kt
@@ -1,7 +1,6 @@
 package net.ninjacat.rowcp.query
 
-import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 internal class QueryParserTest {
@@ -53,10 +52,10 @@ internal class QueryParserTest {
     }
 
     @Test
-    internal fun testFailWhenIncorrectWhere() {
+    internal fun testNotFailWhenIncorrectWhere() {
         val parser = QueryParser()
-        assertThatThrownBy {
+        assertThatCode {
             parser.parseQuery("SELECT * FROM Table WHERE A = ")
-        }.isInstanceOf(QueryParsingException::class.java)
+        }.doesNotThrowAnyException()
     }
 }


### PR DESCRIPTION
Grammar is only used to verify that all fields are
selected from the table and to ensure that only
one table is used.

Contents of `where` clause are being treated as opaque.