### PR TITLE
Add experimental option to export source data to SQL scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.kotlin.jvm' version '1.4.30'
-    id 'com.github.johnrengelman.shadow' version '6.1.0'
+    id 'org.jetbrains.kotlin.jvm' version '1.5.31'
+    id 'com.github.johnrengelman.shadow' version '7.0.0'
     id 'application'
     id 'antlr'
 }
@@ -9,23 +9,23 @@ plugins {
 mainClassName = 'net.ninjacat.rowcp.AppKt'
 
 group 'net.ninjacat.rowcp'
-version '0.3.0'
+version '0.4.0'
 
 repositories {
     mavenCentral()
 }
 
 ext {
-    antlrVersion = '4.9.1'
-    jansiVersion = '2.2.0'
-    jcommanderVersion = '1.78'
-    mariaDbVersion = '2.7.2'
-    postgresVersion = '42.2.18'
+    antlrVersion = '4.9.2'
+    jansiVersion = '2.3.4'
+    jcommanderVersion = '1.81'
+    mariaDbVersion = '2.7.3'
+    postgresVersion = '42.2.24'
     h2Version = '1.4.200'
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib"
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.5.31'
 
     antlr "org.antlr:antlr4:$antlrVersion"
     implementation "org.antlr:antlr4-runtime:$antlrVersion"
@@ -37,27 +37,44 @@ dependencies {
     implementation "org.postgresql:postgresql:$postgresVersion"
     implementation "com.h2database:h2:$h2Version"
 
-    implementation 'ch.qos.logback:logback-classic:1.2.3'
+    implementation 'ch.qos.logback:logback-classic:1.2.6'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-    testImplementation "org.assertj:assertj-core:3.18.1"
-    testImplementation 'org.liquibase:liquibase-core:4.2.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation 'org.assertj:assertj-core:3.21.0'
+    testImplementation 'org.liquibase:liquibase-core:4.4.3'
     testImplementation 'com.h2database:h2:1.4.200'
-    testImplementation 'io.mockk:mockk:1.10.5'
+    testImplementation 'io.mockk:mockk:1.12.0'
 }
 
 generateGrammarSource {
     arguments += ["-visitor"]
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 compileJava.dependsOn generateGrammarSource
-compileKotlin.dependsOn generateGrammarSource
+
+compileKotlin {
+    dependsOn generateGrammarSource
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+}
 
 test {
     useJUnitPlatform()
 }
 
+jar {
+    archiveClassifier.set('non-bin')
+}
+
 shadowJar {
+    dependsOn jar
     archiveClassifier.set('')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/readme.md
+++ b/readme.md
@@ -43,9 +43,20 @@ There are some rules this query must abide by:
 - `WHERE` clause must be present to limit the number of rows selected
 - it must be a valid SQL query in the SQL dialect of the source database
 
-There is no limitation on what you can have in `WHERE` clause, but it is highly recommended to limit the number of rows
-copied to be small (in the 1 to 10 range), as, depending on the number of relationships, the actual number of copied rows
-can grow exponentially and rowcp is not build for speed and efficiency.
+There is no limitation on what you can have in `WHERE` clause, but it is highly recommended limiting the number of rows
+copied to be small (in the 1 to 10 range), as, depending on the number of relationships, the actual number of copied
+rows can grow exponentially and rowcp is not build for speed and efficiency.
+
+### Exporting source data as SQL statements
+
+Instead of inserting/updating the target database, rowcp can create SQL statements for each row from the source
+database.
+
+If `--target-connection` starts with `file:` schema instead of `jdbc:` schema, then the rest of the connection line will
+be used as a name of the file to which the `INSERT INTO` statements will be written.
+
+Some options, such as `--target-user`, `--target-password` and `--update` are ignored when the target is a file. This
+mode is experimental, please review the generated SQL statements before executing them.
 
 ### Command line parameters
 

--- a/src/main/kotlin/net/ninjacat/rowcp/Args.kt
+++ b/src/main/kotlin/net/ninjacat/rowcp/Args.kt
@@ -15,7 +15,10 @@ class Args {
     @Parameter(names = ["-h", "--help"], description = "Show this mesage")
     var showHelp: Boolean = false
 
-    @Parameter(names = ["-s", "--source-connection"], description = "Source JDBC connection string")
+    @Parameter(
+        names = ["-s", "--source-connection"],
+        description = "Source JDBC connection string or a file path starting with 'file:' schema"
+    )
     var sourceJdbcUrl: String = ""
 
     @Parameter(names = ["--source-user"], description = "User name for source database")
@@ -65,7 +68,7 @@ class Args {
     @Parameter(description = "Query")
     var query: MutableList<String> = mutableListOf()
 
-    val tablesToSkip: Set<String> by lazy { skipSourceTables?.split(",")?.map { it.toLowerCase() }?.toSet() ?: setOf() }
+    val tablesToSkip: Set<String> by lazy { skipSourceTables?.split(",")?.map { it.lowercase() }?.toSet() ?: setOf() }
 
     private fun validate(): Args {
         if (showHelp) {

--- a/src/main/kotlin/net/ninjacat/rowcp/data/DataCopier.kt
+++ b/src/main/kotlin/net/ninjacat/rowcp/data/DataCopier.kt
@@ -9,7 +9,7 @@ class DataCopier(
     private val args: Args,
     private val parser: QueryParser,
     private val retriever: DataRetriever,
-    private val mapper: DataMapper,
+    private val mapper: Mapper,
     private val writer: DataWriter
 ) {
 

--- a/src/main/kotlin/net/ninjacat/rowcp/data/DataMapper.kt
+++ b/src/main/kotlin/net/ninjacat/rowcp/data/DataMapper.kt
@@ -4,9 +4,9 @@ import net.ninjacat.rowcp.Args
 
 class ValidationException(message: String) : RuntimeException(message)
 
-class DataMapper(val args: Args, val targetSchema: DbSchema) {
+class DataMapper(val args: Args, val targetSchema: DbSchema) : Mapper {
 
-    fun mapToTarget(source: DataNode): DataNode {
+    override fun mapToTarget(source: DataNode): DataNode {
         val before = source.before.map { mapToTarget(it) }
         val after = source.after.map { mapToTarget(it) }
 

--- a/src/main/kotlin/net/ninjacat/rowcp/data/DataRetriever.kt
+++ b/src/main/kotlin/net/ninjacat/rowcp/data/DataRetriever.kt
@@ -3,7 +3,10 @@ package net.ninjacat.rowcp.data
 import net.ninjacat.rowcp.*
 import net.ninjacat.rowcp.query.Query
 import java.lang.Integer.min
-import java.sql.*
+import java.sql.Connection
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.SQLSyntaxErrorException
 
 data class SelectRelationship(
     val sourceTableName: String,
@@ -192,7 +195,7 @@ class DataRetriever(val params: Args, private val schema: DbSchema) {
     private fun toDataRow(rs: ResultSet, table: Table): DataRow {
         val result = mutableListOf<ColumnData>()
         for (i in 1..rs.metaData.columnCount) {
-            val columnName = rs.metaData.getColumnName(i).toLowerCase()
+            val columnName = rs.metaData.getColumnName(i).lowercase()
             val columnType = rs.metaData.getColumnType(i)
             val value = rs.getObject(i)
             result.add(ColumnData(columnName, columnType, value))

--- a/src/main/kotlin/net/ninjacat/rowcp/data/DbSchema.kt
+++ b/src/main/kotlin/net/ninjacat/rowcp/data/DbSchema.kt
@@ -27,7 +27,7 @@ class DbSchema(jdbcUrl: String, user: String?, password: String?) {
             val children = getChildren(tableName)
             val columns = getTableColumns(tableName)
             val pk = getPrimaryKey(tableName)
-            val table = Table(tableName.toLowerCase(), columns, parents, children, pk)
+            val table = Table(tableName.lowercase(), columns, parents, children, pk)
             tables[table.name] = table
         }
         log(V_VERBOSE, "Collected metadata of @|yellow ${tables.size}|@ tables")
@@ -39,7 +39,7 @@ class DbSchema(jdbcUrl: String, user: String?, password: String?) {
         return connection.metaData.getPrimaryKeys(null, null, tableName).use {
             val results = mutableListOf<String>()
             while (next()) {
-                results.add(getString("COLUMN_NAME").toLowerCase())
+                results.add(getString("COLUMN_NAME").lowercase())
             }
             if (results.isEmpty()) {
                 getUniqueKey(tableName)
@@ -53,7 +53,7 @@ class DbSchema(jdbcUrl: String, user: String?, password: String?) {
         return connection.metaData.getBestRowIdentifier(null, null, tableName!!, bestRowTemporary, false).use {
             val results = mutableListOf<String>()
             if (next()) {
-                results.add(getString("COLUMN_NAME").toLowerCase())
+                results.add(getString("COLUMN_NAME").lowercase())
             }
             results.toSet()
         }
@@ -67,13 +67,13 @@ class DbSchema(jdbcUrl: String, user: String?, password: String?) {
         val targetColumns = mutableListOf<String>()
         try {
             while (resultSet.next()) {
-                val targetTableName = resultSet.getString("FKTABLE_NAME").toLowerCase()
-                val targetColumn = resultSet.getString("FKCOLUMN_NAME").toLowerCase()
-                val sourceColumn = resultSet.getString("PKCOLUMN_NAME").toLowerCase()
+                val targetTableName = resultSet.getString("FKTABLE_NAME").lowercase()
+                val targetColumn = resultSet.getString("FKCOLUMN_NAME").lowercase()
+                val sourceColumn = resultSet.getString("PKCOLUMN_NAME").lowercase()
                 if (target != targetTableName) {
                     if (target != "") {
                         results.add(
-                            Relationship(tableName.toLowerCase(), target, zipColumns(thisColumns, targetColumns))
+                            Relationship(tableName.lowercase(), target, zipColumns(thisColumns, targetColumns))
                         )
                         thisColumns.clear()
                         targetColumns.clear()
@@ -85,7 +85,7 @@ class DbSchema(jdbcUrl: String, user: String?, password: String?) {
                 targetColumns.add(targetColumn)
             }
             if (target != "") {
-                results.add(Relationship(tableName.toLowerCase(), target, zipColumns(thisColumns, targetColumns)))
+                results.add(Relationship(tableName.lowercase(), target, zipColumns(thisColumns, targetColumns)))
             }
             return results.toSet()
         } finally {
@@ -101,13 +101,13 @@ class DbSchema(jdbcUrl: String, user: String?, password: String?) {
         val targetColumns = mutableListOf<String>()
         try {
             while (resultSet.next()) {
-                val sourceTableName = resultSet.getString("PKTABLE_NAME").toLowerCase()
-                val sourceColumn = resultSet.getString("PKCOLUMN_NAME").toLowerCase()
-                val targetColumn = resultSet.getString("FKCOLUMN_NAME").toLowerCase()
+                val sourceTableName = resultSet.getString("PKTABLE_NAME").lowercase()
+                val sourceColumn = resultSet.getString("PKCOLUMN_NAME").lowercase()
+                val targetColumn = resultSet.getString("FKCOLUMN_NAME").lowercase()
                 if (source != sourceTableName) {
                     if (source != "") {
                         results.add(
-                            Relationship(source, tableName.toLowerCase(), zipColumns(sourceColumns, targetColumns))
+                            Relationship(source, tableName.lowercase(), zipColumns(sourceColumns, targetColumns))
                         )
                         sourceColumns.clear()
                         targetColumns.clear()
@@ -119,7 +119,7 @@ class DbSchema(jdbcUrl: String, user: String?, password: String?) {
                 targetColumns.add(targetColumn)
             }
             if (source != "") {
-                results.add(Relationship(source, tableName.toLowerCase(), zipColumns(sourceColumns, targetColumns)))
+                results.add(Relationship(source, tableName.lowercase(), zipColumns(sourceColumns, targetColumns)))
             }
             return results.toSet()
         } finally {
@@ -132,7 +132,7 @@ class DbSchema(jdbcUrl: String, user: String?, password: String?) {
         val columns = mutableListOf<Column>()
         try {
             while (resultSet.next()) {
-                val name = resultSet.getString("COLUMN_NAME").toLowerCase()
+                val name = resultSet.getString("COLUMN_NAME").lowercase()
                 val type = resultSet.getInt("DATA_TYPE")
                 columns.add(Column(name, type))
             }

--- a/src/main/kotlin/net/ninjacat/rowcp/data/Mapper.kt
+++ b/src/main/kotlin/net/ninjacat/rowcp/data/Mapper.kt
@@ -1,0 +1,21 @@
+/*
+ *    Copyright 2021 Oleksiy Voronin
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.ninjacat.rowcp.data
+
+interface Mapper {
+    fun mapToTarget(source: DataNode): DataNode
+}

--- a/src/main/kotlin/net/ninjacat/rowcp/data/Utils.kt
+++ b/src/main/kotlin/net/ninjacat/rowcp/data/Utils.kt
@@ -5,6 +5,9 @@ import java.net.URI
 object Utils {
 
     fun initializeDatabase(jdbcUrl: String) {
+        if (jdbcUrl.startsWith("file:")) {
+            return
+        }
         if (!jdbcUrl.startsWith("jdbc:")) {
             throw RuntimeException("Invalid JDBC connection string: @|yellow $jdbcUrl")
         }

--- a/src/main/kotlin/net/ninjacat/rowcp/data/export/SqlMapper.kt
+++ b/src/main/kotlin/net/ninjacat/rowcp/data/export/SqlMapper.kt
@@ -1,0 +1,24 @@
+/*
+ *    Copyright 2021 Oleksiy Voronin
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.ninjacat.rowcp.data.export
+
+import net.ninjacat.rowcp.data.DataNode
+import net.ninjacat.rowcp.data.Mapper
+
+class SqlMapper : Mapper {
+    override fun mapToTarget(source: DataNode): DataNode = source
+}

--- a/src/main/kotlin/net/ninjacat/rowcp/data/export/SqlWriter.kt
+++ b/src/main/kotlin/net/ninjacat/rowcp/data/export/SqlWriter.kt
@@ -1,0 +1,63 @@
+/*
+ *    Copyright 2021 Oleksiy Voronin
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package net.ninjacat.rowcp.data.export
+
+import net.ninjacat.rowcp.V_NORMAL
+import net.ninjacat.rowcp.V_VERBOSE
+import net.ninjacat.rowcp.data.DataNode
+import net.ninjacat.rowcp.data.DataWriter
+import net.ninjacat.rowcp.log
+import java.io.File
+import java.io.FileOutputStream
+import java.io.PrintStream
+
+class SqlWriter(targetUrl: String) : DataWriter {
+
+    private val fileName = targetUrl.substring(5)
+
+    override fun writeData(startingNode: DataNode) {
+        val updates = prepareUpdates(startingNode)
+
+        val printer =
+            if (fileName == "--" || fileName == "stdout") {
+                System.out
+            } else {
+                log(V_NORMAL, "Writing SQL statements into @|blue ${fileName}|@")
+                PrintStream(FileOutputStream(File(fileName)))
+            }
+
+        updates.forEach { printer.println(it) }
+        printer.flush()
+    }
+
+    fun prepareUpdates(startingNode: DataNode): List<String> {
+        val beforeUpdates = startingNode.before.flatMap { prepareUpdates(it) }
+        val afterUpdates = startingNode.after.flatMap { prepareUpdates(it) }
+
+        log(V_VERBOSE, "Preprocessing rows for ${startingNode.tableName}")
+        val updates = startingNode.rows.map { row ->
+            val columnNames = row.columns.map { it.columnName }
+            val columnValue = row.columns.map { it.asSqlText() }
+            "INSERT INTO ${row.table.name}(${columnNames.joinToString(", ")})\n" +
+                    "VALUES(${columnValue.joinToString(", ")})"
+        }
+
+        return beforeUpdates + updates + afterUpdates
+    }
+}
+
+


### PR DESCRIPTION
Add "file:" schema support for target URL (as in `/path/to/file.sql`) to export data from source schema to SQL script.
Bump dependency versions and fix deprecation warnings